### PR TITLE
Change DEFAULT_ID from int to string

### DIFF
--- a/tuya.py
+++ b/tuya.py
@@ -14,7 +14,7 @@ REQUIREMENTS = ['pytuya==5.0']
 CONF_DEVICE_ID = 'device_id'
 CONF_LOCAL_KEY = 'local_key'
 
-DEFAULT_ID = 1
+DEFAULT_ID = '1'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_NAME): cv.string,


### PR DESCRIPTION
This fixes a error in log 

  File "/config/custom_components/switch/tuya.py", line 79, in update
    self._state = status['dps'][self._switchid]
KeyError: 1