### PR TITLE
Use one host for multiple switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,25 @@ switch:
     device_id: xxxxxxxxxxxxxxxxxxxx
     id: 3
 ```
+
+Multiple switches on a single device:
+```
+switch:
+  - platform: tuya
+    host: xxx.xxx.xxx.xxx
+    local_key: xxxxxxxxxxxxxxxx
+    device_id: xxxxxxxxxxxxxxxxxxxx
+    switches:
+      switch1:
+        friendly_name: Switch 1
+        id: 1
+      switch2:
+        friendly_name: Switch 2
+        id: 2
+      switch3:
+        friendly_name: Switch 3
+        id: 3
+      switch4:
+        friendly_name: Switch 4
+        id: 4
+```

--- a/tuya.py
+++ b/tuya.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/switch.tuya/
 """
 import voluptuous as vol
 from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
-from homeassistant.const import (CONF_NAME, CONF_HOST, CONF_ID)
+from homeassistant.const import (CONF_NAME, CONF_HOST, CONF_ID, CONF_SWITCHES, CONF_FRIENDLY_NAME)
 import homeassistant.helpers.config_validation as cv
 from time import time
 from threading import Lock
@@ -18,12 +18,19 @@ CONF_LOCAL_KEY = 'local_key'
 
 DEFAULT_ID = '1'
 
+SWITCH_SCHEMA = vol.Schema({
+    vol.Optional(CONF_ID, default=DEFAULT_ID): cv.string,
+    vol.Optional(CONF_FRIENDLY_NAME): cv.string,
+})
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_NAME): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_DEVICE_ID): cv.string,
     vol.Required(CONF_LOCAL_KEY): cv.string,
     vol.Optional(CONF_ID, default=DEFAULT_ID): cv.string,
+    vol.Optional(CONF_SWITCHES, default={}):
+        vol.Schema({cv.slug: SWITCH_SCHEMA}),
 })
 
 
@@ -31,18 +38,37 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up of the Tuya switch."""
     import pytuya
 
-    add_devices([TuyaDevice(
-        TuyaCache(
-            pytuya.OutletDevice(
-                config.get(CONF_DEVICE_ID),
-                config.get(CONF_HOST),
-                config.get(CONF_LOCAL_KEY),
-            )
-        ),
-        config.get(CONF_NAME),
-        config.get(CONF_ID)
-    )])
+    devices = config.get(CONF_SWITCHES)
+    switches = []
 
+    outlet_device = TuyaCache(
+        pytuya.OutletDevice(
+            config.get(CONF_DEVICE_ID),
+            config.get(CONF_HOST),
+            config.get(CONF_LOCAL_KEY)
+        )
+    )
+
+    for object_id, device_config in devices.items():
+        switches.append(
+                TuyaDevice(
+                    outlet_device,
+                    device_config.get(CONF_FRIENDLY_NAME, object_id),
+                    device_config.get(CONF_ID),
+                )
+        )
+
+    name = config.get(CONF_NAME)
+    if name:
+        switches.append(
+                TuyaDevice(
+                    outlet_device,
+                    name,
+                    config.get(CONF_ID)
+                )
+        )
+
+    add_devices(switches)
 
 class TuyaCache:
     """Cache wrapper for pytuya.OutletDevice"""


### PR DESCRIPTION
Adds ability to use multiple switches on a single device. Doing this with multiple switch calls results in excessive http requests to the tuya device on `update()`. This uses a cache class which will temporarily cache the status results.

Implements the same 'switches' argument as [switch.broadlink](https://home-assistant.io/components/switch.broadlink/).

Example:
```yaml
  - platform: tuya
    host: xxx.xxx.xxx.xxx
    local_key: xxxxxxxxxxxxxxxx
    device_id: xxxxxxxxxxxxxxxxxxxx
    switches:
      switch1:
        friendly_name: Switch 1
        id: 1
      switch2:
        friendly_name: Switch 2
        id: 2
      switch3:
        friendly_name: Switch 3
        id: 3
      switch4:
        friendly_name: Switch 4
        id: 4
```